### PR TITLE
Hotfix: prevent tests from ever connecting to a real database

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,50 @@
+"""
+Test isolation safety net.
+
+INCIDENT (2026-07-18): a test fixture ran DELETE against the real VRCVerify
+production database because the test process loaded the developer's real
+.env file, which points DATABASE_URL_VRCVERIFY at a live, reachable Postgres
+host. python-dotenv's load_dotenv() does not override variables that are
+already set in the environment, so setting these here -- before any src/
+module is imported -- guarantees every service binds to an isolated
+in-memory sqlite database for the whole test session, regardless of what a
+developer's .env contains.
+
+pytest always imports conftest.py before collecting test modules, so this
+runs first.
+"""
+import os
+import sys
+
+_SAFE_DB_URL = "sqlite:///:memory:"
+for _var in ("DATABASE_URL_VERIFICATION", "DATABASE_URL_DJ", "DATABASE_URL_VRCVERIFY"):
+    os.environ[_var] = _SAFE_DB_URL
+
+# Also keep RabbitMQ pointed somewhere inert. No current test connects to a
+# real broker (pika.BlockingConnection is always mocked), but this closes
+# the door on a future test doing so by accident.
+os.environ.setdefault("RABBITMQ_HOST", "invalid.test.local")
+
+
+def pytest_runtest_setup(item):
+    """Hard safety net, re-checked before every single test: if any
+    already-imported service module ended up bound to a non-sqlite database
+    engine -- for any reason, including future code changes that bypass the
+    override above -- abort immediately instead of risking a write to a
+    real database.
+    """
+    for modname in ("subscription_manager", "subscription_checker", "bot", "stripe_webhook_service"):
+        mod = sys.modules.get(modname) or sys.modules.get(f"src.{modname}")
+        if mod is None:
+            continue
+        for attr_name in dir(mod):
+            if not attr_name.startswith("engine"):
+                continue
+            engine = getattr(mod, attr_name, None)
+            url = getattr(engine, "url", None)
+            if url is not None and "sqlite" not in str(url):
+                raise RuntimeError(
+                    f"UNSAFE TEST ENVIRONMENT: {modname}.{attr_name} is bound to a "
+                    f"non-sqlite database ({url}). Refusing to run '{item.nodeid}' "
+                    f"to prevent touching a real database."
+                )


### PR DESCRIPTION
## Summary

**Incident, 2026-07-18:** running `pytest` the normal way (no manual environment overrides) caused a test fixture added in Phase 0 (`vrcverify_db` in `tests/test_subscription_manager.py`) to run `DELETE` against the real, reachable production VRCVerify Postgres database, because the test process loaded the real `.env` file — which points `DATABASE_URL_VRCVERIFY` at that live host — instead of an isolated test database. Every earlier verification of that test suite happened to explicitly override the DB env vars, so this failure mode was never exercised until tests were run the way a developer normally would.

Phillip confirmed a same-day backup exists; recovery was his action, not something attempted here.

## Fix

Added `tests/conftest.py`, which:
1. Force-sets `DATABASE_URL_VERIFICATION`, `DATABASE_URL_DJ`, and `DATABASE_URL_VRCVERIFY` to `sqlite:///:memory:` before any `src/` module is imported. `python-dotenv`'s `load_dotenv()` never overrides already-set environment variables, so this makes every subsequent `load_dotenv()` call in the service modules a no-op for these three variables — regardless of what a developer's `.env` contains or how pytest is invoked (CI, plain `pytest`, an IDE test runner).
2. Adds a `pytest_runtest_setup` hook that re-checks, before **every single test**, that any already-imported service module's SQLAlchemy engine(s) are still bound to sqlite. If not, it raises immediately instead of letting the test body run — defense in depth, independent of the override above, in case a future code change bypasses it.
3. Defaults `RABBITMQ_HOST` to an inert placeholder, closing the door on a future test accidentally opening a real broker connection (no current test does this — `pika.BlockingConnection` is always mocked).

Also relevant, on a separate branch not yet merged: the `restrict-to-verifyme-database` branch removes the DJ/VRCVerify code from `subscription_manager.py`/`subscription_checker.py` entirely, which independently closes this gap at the code level. This PR is the test-side safety net; that one is the structural fix.

## Test plan

- [x] `pytest` with **zero** environment overrides now passes 11/11 against fully isolated in-memory databases
- [x] Verified the safety-net hook actually fires: deliberately rebound an engine to a fake, never-real address (`203.0.113.99`, a TEST-NET-3 address — guaranteed non-routable, never production) and confirmed `pytest_runtest_setup` raises before the test body runs