### PR TITLE
Phase 2: Shared data models, Alembic migrations, and correctness fixes

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,42 @@
+# Alembic configuration for VerifyMe.
+# The database URL is NOT set here — alembic/env.py reads it from the
+# DATABASE_URL_VERIFICATION environment variable (or .env), the same way the
+# services do. This repo only ever connects to verify_me_database.
+
+[alembic]
+script_location = alembic
+prepend_sys_path = src
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,63 @@
+import os
+import sys
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from dotenv import load_dotenv
+
+from alembic import context
+
+# Make src/ importable so we can load the models' metadata
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+load_dotenv()
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# This repo only ever connects to verify_me_database.
+database_url = os.getenv("DATABASE_URL_VERIFICATION")
+if not database_url:
+    raise EnvironmentError("DATABASE_URL_VERIFICATION must be set to run migrations")
+config.set_main_option("sqlalchemy.url", database_url)
+
+from models import Base  # noqa: E402
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode (emit SQL without a DB connection)."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode (connect and execute)."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/0001_baseline.py
+++ b/alembic/versions/0001_baseline.py
@@ -1,0 +1,69 @@
+"""Baseline: users, servers, command_usage as defined in src/models.py.
+
+For an EXISTING database that already has these tables (e.g. the current
+production verify_me_database), do NOT run upgrade — mark it as already
+at this revision instead:
+
+    alembic stamp head
+
+For a FRESH database:
+
+    alembic upgrade head
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-07-18
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("discord_id", sa.String(length=50), nullable=False),
+        sa.Column("verification_status", sa.Boolean(), nullable=True),
+        sa.Column("last_verification_attempt", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("dob", sa.String(length=255), nullable=True),
+    )
+    op.create_table(
+        "servers",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("server_id", sa.String(length=30), nullable=False, unique=True),
+        sa.Column("owner_id", sa.String(length=30), nullable=False),
+        sa.Column("role_id", sa.String(length=30), nullable=True),
+        sa.Column("tier", sa.String(length=50), nullable=True),
+        sa.Column("subscription_status", sa.Boolean(), nullable=True),
+        sa.Column("verifications_count", sa.Integer(), nullable=True),
+        sa.Column("subscription_start_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("stripe_subscription_id", sa.String(length=255), nullable=True),
+        sa.Column("minimum_age", sa.Integer(), nullable=False, server_default="18"),
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("last_renewal_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("instructions_channel_id", sa.String(length=30), nullable=True),
+        sa.Column("instructions_message_id", sa.String(length=30), nullable=True),
+    )
+    op.create_table(
+        "command_usage",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("server_id", sa.String(length=30), nullable=False),
+        sa.Column("user_id", sa.String(length=30), nullable=False),
+        sa.Column("command", sa.String(length=50), nullable=False),
+        sa.Column("timestamp", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("command_usage")
+    op.drop_table("servers")
+    op.drop_table("users")

--- a/src/bot.py
+++ b/src/bot.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 import discord
 from discord import app_commands
+from dateutil.relativedelta import relativedelta
 from dotenv import load_dotenv
 import pika
 import stripe
@@ -496,8 +497,8 @@ async def verify(interaction: discord.Interaction):
                     # Make the decrypted_dob timezone-aware (UTC)
                     decrypted_dob = decrypted_dob.replace(tzinfo=timezone.utc)
                     
-                    # Calculate the user's age
-                    user_age = (datetime.now(timezone.utc) - decrypted_dob).days // 365
+                    # Calculate the user's age in calendar years (leap-year safe)
+                    user_age = relativedelta(datetime.now(timezone.utc), decrypted_dob).years
                     
                     if user_age < server_config.minimum_age:
                         await interaction.followup.send(f"You must be at least {server_config.minimum_age} years old to be added to the role.", ephemeral=True)

--- a/src/bot.py
+++ b/src/bot.py
@@ -511,21 +511,31 @@ async def verify(interaction: discord.Interaction):
 
             # Check cooldown if user exists and is not verified
             if user and user.last_verification_attempt:
-                logger.debug(f"User last verification attempt (UTC): {user.last_verification_attempt}")
+                last_attempt = user.last_verification_attempt
+                if last_attempt.tzinfo is None:
+                    # sqlite returns naive datetimes even for tz-aware columns
+                    last_attempt = last_attempt.replace(tzinfo=timezone.utc)
 
                 current_time_utc = datetime.now(timezone.utc)
-                logger.debug(f"Current time (UTC): {current_time_utc}")
+                cooldown_end = last_attempt + timedelta(seconds=COOLDOWN_PERIOD)
 
-                if current_time_utc - user.last_verification_attempt < timedelta(seconds=COOLDOWN_PERIOD):
-                    cooldown_end = user.last_verification_attempt + timedelta(seconds=COOLDOWN_PERIOD)
+                if current_time_utc < cooldown_end:
+                    remaining = int((cooldown_end - current_time_utc).total_seconds()) + 1
                     logger.debug(f"User {interaction.user.id} is in cooldown period until: {cooldown_end}")
-                    await interaction.followup.send(f"You're in a cooldown period. Please wait before attempting to verify again.", ephemeral=True)
+                    await interaction.followup.send(
+                        f"You're in a cooldown period. Please wait {remaining} seconds before attempting to verify again.",
+                        ephemeral=True,
+                    )
                     return
 
             # Check if there are available verifications for the server
             if server_config.verifications_count <= 0:
                 await interaction.followup.send("This server has reached its monthly verification limit. Please contact an admin to upgrade the plan or wait until next month.", ephemeral=True)
                 return
+
+            # Record the attempt BEFORE generating the Stripe URL, so a rapid
+            # double-click can't create two verification sessions.
+            await track_verification_attempt(user_id)
 
             # Directly generate a Stripe verification URL and send it (no second button)
             logger.debug(f"Generating Stripe verification URL for user {interaction.user.id}")
@@ -537,8 +547,6 @@ async def verify(interaction: discord.Interaction):
                 await interaction.followup.send("Failed to initiate the verification process. Please try again later or contact support.", ephemeral=True)
                 return
 
-            # Track verification attempt and usage
-            await track_verification_attempt(user_id)
             bot.loop.create_task(track_command_usage(guild_id, interaction.user.id, "verify"))
 
             await interaction.followup.send(

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,21 +1,21 @@
-import hashlib
 import os
 import json
 import asyncio
 import logging
 import time
 from datetime import datetime, timedelta, timezone
-from contextlib import contextmanager
 
 import discord
 from discord import app_commands
 from dotenv import load_dotenv
 import pika
 import stripe
-from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime, text, inspect
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
 from cryptography.fernet import Fernet
+
+try:
+    from .models import User, Server, CommandUsage, session_scope
+except ImportError:
+    from models import User, Server, CommandUsage, session_scope
 
 # Load environment variables
 load_dotenv()
@@ -36,7 +36,6 @@ logging.getLogger('pika').setLevel(getattr(logging, PIKA_LOG_LEVEL, logging.WARN
 # Retrieve environment variables
 DISCORD_BOT_TOKEN = os.getenv('DISCORD_BOT_TOKEN')
 STRIPE_SECRET_KEY = os.getenv('STRIPE_SECRET_KEY')
-DATABASE_URL = os.getenv('DATABASE_URL_VERIFICATION')
 
 
 # RabbitMQ Configuration
@@ -53,11 +52,6 @@ required_env_vars = ['DISCORD_BOT_TOKEN', 'STRIPE_SECRET_KEY', 'DATABASE_URL_VER
 missing_vars = [var for var in required_env_vars if not os.getenv(var)]
 if missing_vars:
     raise EnvironmentError(f"Missing required environment variables: {', '.join(missing_vars)}")
-
-# Database setup
-engine = create_engine(DATABASE_URL)
-Base = declarative_base()
-Session = sessionmaker(bind=engine)
 
 # Initialize the Discord bot with intents (avoid heavy member chunking at startup)
 intents = discord.Intents.default()
@@ -191,49 +185,6 @@ def decrypt_dob(encrypted_dob: str) -> datetime:
     dob_str = dob_bytes.decode('utf-8')  # Convert bytes back to string
     return datetime.strptime(dob_str, '%Y-%m-%d')  # Convert string to datetime object
 
-# Modify User model to store the encrypted DOB
-class User(Base):
-    __tablename__ = 'users'
-    id = Column(Integer, primary_key=True)
-    discord_id = Column(String(30), nullable=False)
-    verification_status = Column(Boolean, default=False)
-    last_verification_attempt = Column(DateTime(timezone=True))
-    dob = Column(String(255), nullable=True)  # Store encrypted DOB
-
-    @staticmethod
-    def get_current_time():
-        return datetime.now(timezone.utc)
-
-    def set_verification_attempt(self):
-        self.last_verification_attempt = self.get_current_time()
-
-class Server(Base):
-    __tablename__ = 'servers'
-    id = Column(Integer, primary_key=True)
-    server_id = Column(String, unique=True, nullable=False)
-    owner_id = Column(String, nullable=False)
-    role_id = Column(String, nullable=True)
-    tier = Column(String, nullable=False)
-    subscription_status = Column(Boolean, default=False)
-    verifications_count = Column(Integer, default=0)
-    subscription_start_date = Column(DateTime, nullable=True)
-    stripe_subscription_id = Column(String, nullable=True)
-    minimum_age = Column(Integer, nullable=False, default=18)
-    instructions_channel_id = Column(String, nullable=True)
-    instructions_message_id = Column(String, nullable=True)
-
-
-class CommandUsage(Base):
-    __tablename__ = 'command_usage'
-    id = Column(Integer, primary_key=True)
-    server_id = Column(String(30), nullable=False)
-    user_id = Column(String(30), nullable=False)
-    command = Column(String(50), nullable=False)
-    timestamp = Column(DateTime(timezone=True), nullable=False)
-
-# Create tables
-Base.metadata.create_all(engine)
-
 # RabbitMQ setup
 credentials = pika.PlainCredentials(RABBITMQ_USERNAME, RABBITMQ_PASSWORD)
 
@@ -283,18 +234,6 @@ def get_rabbitmq_channel():
     channel = connection.channel()
     channel.queue_declare(queue=RABBITMQ_QUEUE_NAME, durable=True)
     return channel
-
-@contextmanager
-def session_scope():
-    session = Session()
-    try:
-        yield session
-        session.commit()
-    except:
-        session.rollback()
-        raise
-    finally:
-        session.close()
 
 def get_server_config(guild_id):
     with session_scope() as session:

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,97 @@
+"""Single source of truth for VerifyMe's database schema and connection.
+
+Every service imports its models, engine, and session handling from here.
+Do not redefine these models in a service module — the three divergent
+copies that used to exist (bot.py, stripe_webhook_service.py,
+subscription_manager.py) disagreed on column lengths and nullability, and
+whichever service started first won.
+
+This repo is scoped to verify_me_database ONLY (DATABASE_URL_VERIFICATION).
+Never add an engine for any other database here.
+
+Schema changes are managed with Alembic (alembic/ at the repo root), not
+create_all at import time. init_db() exists for tests and local sqlite use.
+"""
+import os
+from contextlib import contextmanager
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+load_dotenv()
+
+DATABASE_URL = os.getenv('DATABASE_URL_VERIFICATION')
+if not DATABASE_URL:
+    raise EnvironmentError("DATABASE_URL_VERIFICATION is not set")
+
+engine = create_engine(DATABASE_URL)
+Base = declarative_base()
+Session = sessionmaker(bind=engine)
+
+
+@contextmanager
+def session_scope():
+    """Provide a transactional scope around a series of operations."""
+    session = Session()
+    try:
+        yield session
+        session.commit()
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    discord_id = Column(String(50), nullable=False)
+    verification_status = Column(Boolean, default=False)
+    last_verification_attempt = Column(DateTime(timezone=True), nullable=True)
+    dob = Column(String(255), nullable=True)  # Fernet-encrypted date of birth
+
+    @staticmethod
+    def get_current_time():
+        return datetime.now(timezone.utc)
+
+    def set_verification_attempt(self):
+        self.last_verification_attempt = self.get_current_time()
+
+
+class Server(Base):
+    __tablename__ = 'servers'
+    id = Column(Integer, primary_key=True)
+    server_id = Column(String(30), unique=True, nullable=False)
+    owner_id = Column(String(30), nullable=False)
+    role_id = Column(String(30), nullable=True)
+    tier = Column(String(50), nullable=True)
+    subscription_status = Column(Boolean, default=False)
+    verifications_count = Column(Integer, default=0)
+    subscription_start_date = Column(DateTime(timezone=True), nullable=True)
+    stripe_subscription_id = Column(String(255), nullable=True)
+    minimum_age = Column(Integer, nullable=False, default=18)
+    email = Column(String(255), nullable=True)
+    last_renewal_date = Column(DateTime(timezone=True), nullable=True)
+    instructions_channel_id = Column(String(30), nullable=True)
+    instructions_message_id = Column(String(30), nullable=True)
+
+
+class CommandUsage(Base):
+    __tablename__ = 'command_usage'
+    id = Column(Integer, primary_key=True)
+    server_id = Column(String(30), nullable=False)
+    user_id = Column(String(30), nullable=False)
+    command = Column(String(50), nullable=False)
+    timestamp = Column(DateTime(timezone=True), nullable=False)
+
+
+def init_db():
+    """Create all tables on the current engine.
+
+    For tests and throwaway local databases only — real deployments manage
+    schema through Alembic migrations.
+    """
+    Base.metadata.create_all(engine)

--- a/src/stripe_webhook_service.py
+++ b/src/stripe_webhook_service.py
@@ -2,7 +2,7 @@ import os
 import json
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any
 
 import pika
@@ -194,7 +194,7 @@ def handle_verification_verified(session_id: str) -> None:
         if user:
             user.verification_status = verification_status
             user.dob = encrypted_dob  # Store the encrypted DOB
-            user.last_verification_attempt = datetime.now()
+            user.last_verification_attempt = datetime.now(timezone.utc)
             logger.info(f"User {user_id} marked as verified with encrypted DOB")
         else:
             # Add new user if not found
@@ -202,7 +202,7 @@ def handle_verification_verified(session_id: str) -> None:
                 discord_id=user_id,
                 verification_status=verification_status,
                 dob=encrypted_dob,  # Store the encrypted DOB
-                last_verification_attempt=datetime.now()
+                last_verification_attempt=datetime.now(timezone.utc)
             )
             db_session.add(new_user)
             logger.info(f"New user {user_id} added with encrypted DOB")
@@ -234,14 +234,14 @@ def handle_verification_canceled(session: Dict[str, Any]) -> None:
         user = db_session.query(User).filter_by(discord_id=user_id).first()
         if user:
             user.verification_status = verification_status
-            user.last_verification_attempt = datetime.now()
+            user.last_verification_attempt = datetime.now(timezone.utc)
             logger.info(f"User {user_id} verification attempt canceled")
         else:
             # Add new user if not found
             new_user = User(
                 discord_id=user_id,
                 verification_status=verification_status,
-                last_verification_attempt=datetime.now()
+                last_verification_attempt=datetime.now(timezone.utc)
             )
             db_session.add(new_user)
             logger.info(f"New user {user_id} added with verification attempt canceled")

--- a/src/stripe_webhook_service.py
+++ b/src/stripe_webhook_service.py
@@ -1,10 +1,8 @@
-import hashlib
 import os
 import json
 import logging
 import time
 from datetime import datetime
-from contextlib import contextmanager
 from typing import Dict, Any
 
 import pika
@@ -12,9 +10,12 @@ import stripe
 from flask import Flask, request
 from dotenv import load_dotenv
 from pika.exceptions import AMQPError
-from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime
-from sqlalchemy.orm import declarative_base, sessionmaker
 from cryptography.fernet import Fernet
+
+try:
+    from .models import User, session_scope
+except ImportError:
+    from models import User, session_scope
 
 # Load environment variables
 load_dotenv()
@@ -29,24 +30,6 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
-
-# Database configuration
-DATABASE_URL = os.getenv('DATABASE_URL_VERIFICATION')
-engine = create_engine(DATABASE_URL)
-Base = declarative_base()
-Session = sessionmaker(bind=engine)
-
-# Define Users model
-class User(Base):
-    __tablename__ = 'users'
-    id = Column(Integer, primary_key=True)
-    discord_id = Column(String(50), nullable=False)
-    verification_status = Column(Boolean, default=False)
-    dob = Column(String(255), nullable=True)  # Store the encrypted DOB
-    last_verification_attempt = Column(DateTime(timezone=True), nullable=False, default=datetime.now)
-
-# Create tables
-Base.metadata.create_all(engine)
 
 # Stripe setup
 stripe.api_key = os.getenv('STRIPE_RESTRICTED_SECRET_KEY')
@@ -85,18 +68,6 @@ def _rabbitmq_parameters() -> pika.ConnectionParameters:
         retry_delay=retry_delay,
         socket_timeout=socket_timeout,
     )
-
-@contextmanager
-def session_scope():
-    session = Session()
-    try:
-        yield session
-        session.commit()
-    except:
-        session.rollback()
-        raise
-    finally:
-        session.close()
 
 # Encryption/Decryption setup
 DOB_KEY = os.getenv('DOB_KEY')

--- a/src/subscription_checker.py
+++ b/src/subscription_checker.py
@@ -2,11 +2,12 @@ import os
 import logging
 from datetime import datetime, timezone, timedelta
 from apscheduler.schedulers.background import BackgroundScheduler
-from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
 from dotenv import load_dotenv
-from contextlib import contextmanager
+
+try:
+    from .models import Server, session_scope
+except ImportError:
+    from models import Server, session_scope
 
 # -------------------------------------------------------------------
 #  Load environment variables and set up logging
@@ -19,50 +20,6 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
-
-# -------------------------------------------------------------------
-#  Verification DB Setup
-#
-#  This service is scoped to the VerifyMe verification database ONLY. It
-#  must never construct a connection to any other database -- the DJ and
-#  VRCVerify products no longer bill through Stripe/this repo.
-# -------------------------------------------------------------------
-DATABASE_URL_VERIFICATION = os.getenv('DATABASE_URL_VERIFICATION')
-engine_verification = create_engine(DATABASE_URL_VERIFICATION)
-BaseVerification = declarative_base()
-SessionVerification = sessionmaker(bind=engine_verification)
-
-class Server(BaseVerification):
-    __tablename__ = 'servers'
-    id = Column(Integer, primary_key=True)
-    server_id = Column(String(30), nullable=False, unique=True)
-    owner_id = Column(String(30), nullable=False)
-    tier = Column(String(50), nullable=True)
-    subscription_status = Column(Boolean, default=False)
-    verifications_count = Column(Integer, default=0)
-    subscription_start_date = Column(DateTime(timezone=True), nullable=True)
-    stripe_subscription_id = Column(String(255), nullable=True)
-    role_id = Column(String(30), nullable=True)
-    email = Column(String(255), nullable=True)
-    # Must exist in your actual DB via migration:
-    last_renewal_date = Column(DateTime(timezone=True), nullable=True)
-
-BaseVerification.metadata.create_all(engine_verification)
-
-@contextmanager
-def session_scope_verification():
-    """Context manager for the Verification DB session."""
-    session = SessionVerification()
-    try:
-        yield session
-        session.commit()
-    except Exception as e:
-        session.rollback()
-        logging.error(f"[Verification DB] Error during session scope: {e}")
-        raise
-    finally:
-        session.close()
-
 
 # -------------------------------------------------------------------
 #  Weekly Fallback Check
@@ -79,7 +36,7 @@ def check_subscriptions():
     one_month_ago = now - timedelta(days=31)
 
     try:
-        with session_scope_verification() as db_session_v:
+        with session_scope() as db_session_v:
             servers = db_session_v.query(Server).filter(
                 Server.subscription_status == True,
                 Server.last_renewal_date <= one_month_ago

--- a/src/subscription_manager.py
+++ b/src/subscription_manager.py
@@ -2,13 +2,14 @@ import os
 import stripe
 import threading
 from flask import Flask, request, jsonify
-from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
 from dotenv import load_dotenv
-from contextlib import contextmanager
 import logging
 from datetime import datetime, timezone
+
+try:
+    from .models import Server, session_scope
+except ImportError:
+    from models import Server, session_scope
 
 # Load environment variables
 load_dotenv()
@@ -18,50 +19,6 @@ app = Flask(__name__)
 # Stripe configuration
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 endpoint_secret = os.getenv('STRIPE_PAYMENT_WEBHOOK_SECRET')
-
-# This service is scoped to the VerifyMe verification database ONLY. It must
-# never construct a connection to any other database (DJ, VRCVerify, etc.) --
-# those products no longer bill through Stripe/this repo.
-DATABASE_URL_VERIFICATION = os.getenv('DATABASE_URL_VERIFICATION')
-engine_verification = create_engine(DATABASE_URL_VERIFICATION)
-
-BaseVerification = declarative_base()
-SessionVerification = sessionmaker(bind=engine_verification)
-
-# ------------------------
-#  VERIFICATION SERVICE
-# ------------------------
-class Server(BaseVerification):
-    __tablename__ = 'servers'
-    id = Column(Integer, primary_key=True)
-    server_id = Column(String(30), nullable=False, unique=True)
-    owner_id = Column(String(30), nullable=False)
-    tier = Column(String(50), nullable=True)
-    subscription_status = Column(Boolean, default=False)
-    verifications_count = Column(Integer, default=0)
-    subscription_start_date = Column(DateTime(timezone=True), nullable=True)
-    stripe_subscription_id = Column(String(255), nullable=True)
-    role_id = Column(String(30), nullable=True)
-    email = Column(String(255), nullable=True)
-    last_renewal_date = Column(DateTime(timezone=True), nullable=True)
-
-
-# Create tables (or run migrations in production!)
-BaseVerification.metadata.create_all(engine_verification)
-
-@contextmanager
-def session_scope():
-    session = SessionVerification()
-    try:
-        yield session
-        session.commit()
-        logging.info("Transaction committed.")
-    except Exception as e:
-        session.rollback()
-        logging.error(f"Error during session scope: {e}")
-        raise
-    finally:
-        session.close()
 
 # Logging setup
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO').upper()

--- a/src/subscription_manager.py
+++ b/src/subscription_manager.py
@@ -295,8 +295,24 @@ def handle_verification_subscription_update(subscription_id, status, metadata, c
                 if tier_info:
                     server.tier = tier_info['tier']
 
-                # Update last_renewal_date if we have a new current_period_start
                 if current_period_start_dt:
+                    # A renewal is when the billing period advances past the
+                    # stored last_renewal_date. On each renewal, reset the
+                    # monthly verification allowance to the tier amount
+                    # (no rollover of unused tokens).
+                    last_renewal = server.last_renewal_date
+                    if last_renewal is not None and last_renewal.tzinfo is None:
+                        # sqlite returns naive datetimes even for tz-aware columns
+                        last_renewal = last_renewal.replace(tzinfo=timezone.utc)
+
+                    is_renewal = last_renewal is None or current_period_start_dt > last_renewal
+                    if is_renewal and tier_info and status == 'active':
+                        server.verifications_count = tier_info['tokens']
+                        logging.info(
+                            f"Renewal for guild {guild_id}: verification count reset to "
+                            f"{tier_info['tokens']} ({tier_info['tier']})."
+                        )
+
                     server.last_renewal_date = current_period_start_dt
 
                 # Keep subscription_start_date for analytics, no immediate changes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,20 @@ os.environ["DATABASE_URL_VERIFICATION"] = "sqlite:///:memory:"
 # the door on a future test doing so by accident.
 os.environ.setdefault("RABBITMQ_HOST", "invalid.test.local")
 
+# Services no longer run create_all at import (schema is managed by Alembic
+# in real deployments), so create the tables on the shared test engine here.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+import models  # noqa: E402  (must come after the env override above)
+
+# Test modules import services both as plain modules ("import subscription_checker")
+# and as package submodules ("import src.subscription_manager"). Without this
+# alias, Python would create two separate module objects for models.py, each
+# with its own engine and its own in-memory sqlite database. Pin one identity
+# so every service — however imported — shares the same test database.
+sys.modules.setdefault("src.models", models)
+
+models.init_db()
+
 
 def pytest_runtest_setup(item):
     """Hard safety net, re-checked before every single test: if any
@@ -36,7 +50,7 @@ def pytest_runtest_setup(item):
     override above -- abort immediately instead of risking a write to a
     real database.
     """
-    for modname in ("subscription_manager", "subscription_checker", "bot", "stripe_webhook_service"):
+    for modname in ("models", "subscription_manager", "subscription_checker", "bot", "stripe_webhook_service"):
         mod = sys.modules.get(modname) or sys.modules.get(f"src.{modname}")
         if mod is None:
             continue

--- a/tests/test_subscription_checker.py
+++ b/tests/test_subscription_checker.py
@@ -8,7 +8,9 @@ import subscription_checker
 
 
 def test_check_subscriptions_queries_verification_db():
-    with patch.object(subscription_checker, "SessionVerification") as mock_session_v:
+    with patch.object(subscription_checker, "session_scope") as mock_scope:
+        mock_session = MagicMock()
+        mock_scope.return_value.__enter__.return_value = mock_session
         subscription_checker.check_subscriptions()
-        mock_session_v.assert_called()
-        mock_session_v.return_value.query.assert_called()
+        mock_scope.assert_called()
+        mock_session.query.assert_called()

--- a/tests/test_subscription_manager.py
+++ b/tests/test_subscription_manager.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
 
 import pytest
 from unittest.mock import patch, MagicMock
+import models
 import src.subscription_manager as subscription_manager
 from src.subscription_manager import (
     Server,
@@ -36,7 +37,7 @@ def test_stripe_webhook(mock_external_systems):
 @pytest.fixture(scope="function")
 def verification_db():
     """Provide a clean verification DB session per test."""
-    session = subscription_manager.SessionVerification()
+    session = models.Session()
     session.query(Server).delete()
     session.commit()
     yield session

--- a/tests/test_subscription_manager.py
+++ b/tests/test_subscription_manager.py
@@ -77,6 +77,58 @@ def test_checkout_routing_verification_product():
         mock_handler.assert_called_once()
 
 
+def _tier_product_and_tokens():
+    product_id = next(pid for pid, info in PRODUCT_ID_TO_TIER.items() if info["tokens"] > 0)
+    return product_id, PRODUCT_ID_TO_TIER[product_id]["tokens"]
+
+
+def test_renewal_resets_tokens_to_tier_amount(verification_db):
+    """On renewal (billing period advanced), verifications_count resets to the
+    tier amount — no rollover of unused tokens."""
+    from datetime import datetime, timezone, timedelta
+
+    product_id, tier_tokens = _tier_product_and_tokens()
+    old_renewal = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    verification_db.add(Server(server_id="900", owner_id="901", subscription_status=True,
+                               stripe_subscription_id="sub_renew_1", verifications_count=3,
+                               last_renewal_date=old_renewal))
+    verification_db.commit()
+
+    with patch("src.subscription_manager.stripe.Subscription.retrieve") as mock_retrieve:
+        mock_retrieve.return_value = {"items": {"data": [{"price": {"product": product_id}}]}}
+        subscription_manager.handle_verification_subscription_update(
+            "sub_renew_1", "active", {"guild_id": "900"},
+            old_renewal + timedelta(days=31),
+        )
+
+    verification_db.expire_all()
+    server = verification_db.query(Server).filter_by(server_id="900").first()
+    assert server.verifications_count == tier_tokens
+
+
+def test_non_renewal_update_does_not_reset_tokens(verification_db):
+    """An update within the same billing period (e.g. metadata change) must not
+    touch the remaining token count."""
+    from datetime import datetime, timezone
+
+    product_id, _ = _tier_product_and_tokens()
+    period_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    verification_db.add(Server(server_id="910", owner_id="911", subscription_status=True,
+                               stripe_subscription_id="sub_renew_2", verifications_count=7,
+                               last_renewal_date=period_start))
+    verification_db.commit()
+
+    with patch("src.subscription_manager.stripe.Subscription.retrieve") as mock_retrieve:
+        mock_retrieve.return_value = {"items": {"data": [{"price": {"product": product_id}}]}}
+        subscription_manager.handle_verification_subscription_update(
+            "sub_renew_2", "active", {"guild_id": "910"}, period_start,
+        )
+
+    verification_db.expire_all()
+    server = verification_db.query(Server).filter_by(server_id="910").first()
+    assert server.verifications_count == 7
+
+
 def test_verification_subscription_deleted_marks_inactive(verification_db):
     verification_db.add(Server(server_id="777", owner_id="888",
                                 subscription_status=True, stripe_subscription_id="sub_verify_1"))


### PR DESCRIPTION
## Summary

Phase 2 of the improvement roadmap: consolidates the data layer into a single source of truth and fixes the correctness bugs identified in the initial review.

- **Shared `src/models.py`** — `users`/`servers`/`command_usage` were defined independently in three services with disagreeing column lengths, nullability, and columns (whichever service started first won the `create_all` race). Now there's one engine, one Session factory, one `session_scope`, and one definition of each model (the union of all columns); all four services import from it.
- **Alembic migrations** — schema is now managed by migrations instead of `create_all` at import. Baseline revision `0001` matches the models exactly (`alembic check` reports zero drift). No DB URL lives in `alembic.ini` — `env.py` reads `DATABASE_URL_VERIFICATION` like the services do, honoring the repo's verify_me_database-only scope rule.
- **Leap-year-safe age calculation** — `(now - dob).days // 365` drifts ~1 day per 4 years of age; a user could be rejected on their 18th birthday. Now `relativedelta(now, dob).years`.
- **Timezone-aware datetimes** — the identity webhook wrote naive local-time `datetime.now()` into tz-aware columns that bot.py compares against UTC for cooldowns. All four sites now UTC-aware.
- **Monthly token refill** (decision: reset, no rollover) — nothing previously refilled `verifications_count` on renewal despite the advertised "Max Verifications/Month". On each renewal (Stripe `current_period_start` advances past stored `last_renewal_date`, subscription active), the count resets to the tier amount. Same-period updates don't touch it. Tests cover both cases.
- **Cooldown fixes** — the attempt timestamp was recorded *after* Stripe session creation, so a rapid double-click could create two verification sessions; now recorded before. The cooldown message also tells the user how many seconds remain, and the stored timestamp is normalized to UTC-aware before comparison.

## ⚠️ Deployment step required

The existing production `verify_me_database` already has all tables, so after merging, run once (with `DATABASE_URL_VERIFICATION` set):

```
alembic stamp head
```

Do **not** run `upgrade head` against the existing DB — that's only for fresh databases. This is also documented in the migration file's docstring.

## Test plan

- [x] All services compile and import cleanly against the shared models
- [x] `alembic upgrade head` builds the full schema on a throwaway sqlite file; `alembic check` reports no model/migration drift
- [x] Full test suite: 11 passed (two new renewal-refill tests), plain `pytest`, isolated in-memory DB
- [ ] Post-deploy: confirm a real Stripe renewal resets a server's token count to its tier amount