### PR TITLE
Fix Alembic crash on DB URLs containing percent signs

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -21,7 +21,9 @@ if config.config_file_name is not None:
 database_url = os.getenv("DATABASE_URL_VERIFICATION")
 if not database_url:
     raise EnvironmentError("DATABASE_URL_VERIFICATION must be set to run migrations")
-config.set_main_option("sqlalchemy.url", database_url)
+# configparser treats % as interpolation syntax, so a URL containing
+# percent-encoded characters (e.g. in the password) must escape them.
+config.set_main_option("sqlalchemy.url", database_url.replace("%", "%%"))
 
 from models import Base  # noqa: E402
 


### PR DESCRIPTION
## Summary
Every `alembic` command crashed with `ValueError: invalid interpolation syntax` when `DATABASE_URL_VERIFICATION` contains percent signs (e.g. a percent-encoded password). Alembic stores the URL in a `configparser`-backed config, which treats `%` as interpolation syntax.

## Fix
One line in `alembic/env.py`: escape `%` as `%%` before `config.set_main_option()` — the standard fix for this configparser behavior.

## Verification
- `alembic stamp head` + `alembic current` succeed on a scratch sqlite DB
- A URL containing `%20` now passes the config layer cleanly (previously raised)
- Confirmed working against the production database (`alembic current` → `0001 (head)`)